### PR TITLE
Fix code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -134,5 +134,8 @@
     "vm-browserify": "^1.1.2",
     "whatwg-url": "^13.0.0",
     "ws": "^8.16.0"
+  },
+  "dependencies": {
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -2,6 +2,7 @@
 // @ts-check
 const express = require('express');
 const proxyMiddleware = require('express-http-proxy');
+const rateLimit = require('express-rate-limit');
 const { once } = require('events');
 const {
   app: electronApp,
@@ -355,9 +356,15 @@ class AtlasCloudAuthenticator {
 
 const atlasCloudAuthenticator = new AtlasCloudAuthenticator();
 
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 // Proxy endpoint that triggers the sign in flow through configured cloud
 // environment
-expressProxy.use('/authenticate', async (req, res) => {
+expressProxy.use('/authenticate', limiter, async (req, res) => {
   if (req.method !== 'POST') {
     res.statusCode = 400;
     res.end();
@@ -379,7 +386,7 @@ expressProxy.use('/authenticate', async (req, res) => {
   res.end();
 });
 
-expressProxy.use('/logout', async (req, res) => {
+expressProxy.use('/logout', limiter, async (req, res) => {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     res.end();
@@ -391,7 +398,7 @@ expressProxy.use('/logout', async (req, res) => {
   res.end();
 });
 
-expressProxy.use('/x509', async (req, res) => {
+expressProxy.use('/x509', limiter, async (req, res) => {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     res.end();
@@ -410,7 +417,7 @@ expressProxy.use('/x509', async (req, res) => {
   res.end();
 });
 
-expressProxy.use('/projectId', async (req, res) => {
+expressProxy.use('/projectId', limiter, async (req, res) => {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     res.end();


### PR DESCRIPTION
Fixes [https://github.com/akadev1/compass/security/code-scanning/7](https://github.com/akadev1/compass/security/code-scanning/7)

To fix the problem, we need to introduce rate limiting to the Express application. This can be achieved by using the `express-rate-limit` package. We will set up a rate limiter and apply it to the routes that perform authentication and authorization. This will ensure that the number of requests to these routes is limited, mitigating the risk of DoS attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum number of requests per minute).
4. Apply the rate limiter to the routes that perform authentication and authorization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
