### PR TITLE
Fix code scanning alert no. 2: Regular expression injection

### DIFF
--- a/packages/hadron-build/lib/target.js
+++ b/packages/hadron-build/lib/target.js
@@ -333,8 +333,9 @@ class Target {
     /**
      * Remove `.` from version tags for NUGET version
      */
+    const safeChannel = _.escapeRegExp(this.channel);
     const nuggetVersion = this.version.replace(
-      new RegExp(`-${this.channel}\\.(\\d+)`),
+      new RegExp(`-${safeChannel}\\.(\\d+)`),
       `-${this.channel}$1`
     );
 


### PR DESCRIPTION
Fixes [https://github.com/akadev1/compass/security/code-scanning/2](https://github.com/akadev1/compass/security/code-scanning/2)

To fix the problem, we need to sanitize the `this.channel` variable before using it to construct the regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in a string to make it safe for use in a regular expression.

We will:
1. Import the `lodash` library if it is not already imported.
2. Use `_.escapeRegExp` to sanitize `this.channel` before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
