### PR TITLE
Fix code scanning alert no. 8: Insecure temporary file

### DIFF
--- a/packages/hadron-build/commands/upload.js
+++ b/packages/hadron-build/commands/upload.js
@@ -7,7 +7,7 @@
 // eslint-disable-next-line strict
 'use strict';
 const path = require('path');
-const os = require('os');
+const tmp = require('tmp');
 const { promises: fs } = require('fs');
 const { deepStrictEqual } = require('assert');
 const { Octokit } = require('@octokit/rest');
@@ -183,10 +183,8 @@ async function publishGitHubRelease(assets, version, channel, dryRun) {
 
   const versionManifest = generateVersionsForAssets(assets, version, channel);
 
-  const versionManifestPath = path.join(
-    os.tmpdir(),
-    `version-manifest-${version}-${Date.now()}.json`
-  );
+  const tmpFile = tmp.fileSync({ prefix: `version-manifest-${version}-`, postfix: '.json' });
+  const versionManifestPath = tmpFile.name;
 
   await fs.writeFile(
     versionManifestPath,

--- a/packages/hadron-build/package.json
+++ b/packages/hadron-build/package.json
@@ -54,7 +54,8 @@
     "which": "^2.0.2",
     "xvfb-maybe": "^0.2.1",
     "yargs": "^4.8.1",
-    "zip-folder": "^1.0.0"
+    "zip-folder": "^1.0.0",
+    "tmp": "^0.2.3"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-compass": "^1.1.7",


### PR DESCRIPTION
Fixes [https://github.com/akadev1/compass/security/code-scanning/8](https://github.com/akadev1/compass/security/code-scanning/8)

To fix the problem, we should use a well-tested library like `tmp` to create the temporary file securely. The `tmp` library ensures that the file is inaccessible to other users and that the file does not already exist. This change will involve importing the `tmp` library and using it to create the temporary file instead of using `os.tmpdir()` and `path.join()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
