### PR TITLE
Fix code scanning alert no. 10: Information exposure through a stack trace

### DIFF
--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -381,7 +381,8 @@ expressProxy.use('/authenticate', limiter, async (req, res) => {
     res.send(JSON.stringify({ projectId }));
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    console.error("Exception occurred:", err.stack);
+    res.send("An internal server error occurred");
   }
   res.end();
 });
@@ -412,7 +413,8 @@ expressProxy.use('/x509', limiter, async (req, res) => {
     res.send(cert);
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    console.error("Exception occurred:", err.stack);
+    res.send("An internal server error occurred");
   }
   res.end();
 });
@@ -434,7 +436,8 @@ expressProxy.use('/projectId', limiter, async (req, res) => {
     }
   } catch (err) {
     res.statusCode = 500;
-    res.send(err.stack ?? err.message);
+    console.error("Exception occurred:", err.stack);
+    res.send("An internal server error occurred");
   }
   res.end();
 });


### PR DESCRIPTION
Fixes [https://github.com/akadev1/compass/security/code-scanning/10](https://github.com/akadev1/compass/security/code-scanning/10)

To fix the problem, we need to ensure that stack traces are not sent to the client. Instead, we should log the stack trace on the server and send a generic error message to the client. This can be achieved by replacing the `res.send(err.stack ?? err.message)` lines with a logging statement for the stack trace and a generic error message for the client.

We will need to:
1. Add a logging mechanism to log the stack trace on the server.
2. Replace the `res.send(err.stack ?? err.message)` lines with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
