### PR TITLE
Fix code scanning alert no. 1: Unsafe shell command constructed from library input

### DIFF
--- a/packages/atlas-service/package.json
+++ b/packages/atlas-service/package.json
@@ -90,6 +90,7 @@
     "react": "^17.0.2",
     "react-redux": "^8.1.3",
     "redux": "^4.2.1",
-    "redux-thunk": "^2.4.2"
+    "redux-thunk": "^2.4.2",
+    "shell-quote": "^1.8.1"
   }
 }

--- a/packages/atlas-service/src/main.ts
+++ b/packages/atlas-service/src/main.ts
@@ -1,4 +1,5 @@
 import { shell, app } from 'electron';
+import * as shellQuote from 'shell-quote';
 import { URL, URLSearchParams } from 'url';
 import type { AuthFlowType, MongoDBOIDCPlugin } from '@mongodb-js/oidc-plugin';
 import {
@@ -110,7 +111,8 @@ export class CompassAuthService {
       // `browserCommandForOIDCAuth` preference (which will cause loosing
       // internal plugin auth state), we copy oidc-plugin `openBrowser.command`
       // option handling to our openExternal method
-      const child = spawn(browserCommandForOIDCAuth, [url], {
+      const escapedUrl = shellQuote.quote([url]);
+      const child = spawn(browserCommandForOIDCAuth, [escapedUrl], {
         shell: true,
         stdio: 'ignore',
         detached: true,


### PR DESCRIPTION
Fixes [https://github.com/akadev1/compass/security/code-scanning/1](https://github.com/akadev1/compass/security/code-scanning/1)

To fix the problem, we should avoid using the `shell: true` option with the `spawn` function when passing user-controlled input. Instead, we can use the `shell-quote` library to safely escape any special characters in the `url` parameter before embedding it in the command. This will prevent the shell from interpreting any special characters in the `url`.

1. Install the `shell-quote` library if it is not already installed.
2. Import the `shell-quote` library in the file.
3. Use the `shellQuote.quote` method to escape the `url` parameter before passing it to the `spawn` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
