### PR TITLE
Fix code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/packages/compass-web/package.json
+++ b/packages/compass-web/package.json
@@ -134,5 +134,8 @@
     "vm-browserify": "^1.1.2",
     "whatwg-url": "^13.0.0",
     "ws": "^8.16.0"
+  },
+  "dependencies": {
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/packages/compass-web/scripts/electron-proxy.js
+++ b/packages/compass-web/scripts/electron-proxy.js
@@ -2,6 +2,7 @@
 // @ts-check
 const express = require('express');
 const proxyMiddleware = require('express-http-proxy');
+const RateLimit = require('express-rate-limit');
 const { once } = require('events');
 const {
   app: electronApp,
@@ -352,9 +353,15 @@ class AtlasCloudAuthenticator {
 
 const atlasCloudAuthenticator = new AtlasCloudAuthenticator();
 
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 // Proxy endpoint that triggers the sign in flow through configured cloud
 // environment
-expressProxy.use('/authenticate', async (req, res) => {
+expressProxy.use('/authenticate', limiter, async (req, res) => {
   if (req.method !== 'POST') {
     res.statusCode = 400;
     res.end();
@@ -376,7 +383,7 @@ expressProxy.use('/authenticate', async (req, res) => {
   res.end();
 });
 
-expressProxy.use('/logout', async (req, res) => {
+expressProxy.use('/logout', limiter, async (req, res) => {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     res.end();
@@ -388,7 +395,7 @@ expressProxy.use('/logout', async (req, res) => {
   res.end();
 });
 
-expressProxy.use('/x509', async (req, res) => {
+expressProxy.use('/x509', limiter, async (req, res) => {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     res.end();
@@ -407,7 +414,7 @@ expressProxy.use('/x509', async (req, res) => {
   res.end();
 });
 
-expressProxy.use('/projectId', async (req, res) => {
+expressProxy.use('/projectId', limiter, async (req, res) => {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     res.end();


### PR DESCRIPTION
Fixes [https://github.com/akadev1/compass/security/code-scanning/7](https://github.com/akadev1/compass/security/code-scanning/7)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting for our routes. We will configure a rate limiter and apply it to the specific routes that perform expensive operations.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings.
4. Apply the rate limiter to the routes that require protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
